### PR TITLE
Update ERC20_Token.php

### DIFF
--- a/src/ERC20_Token.php
+++ b/src/ERC20_Token.php
@@ -97,7 +97,7 @@ class ERC20_Token extends Contract
 
         $result = $this->call("decimals");
         $scale = intval($result[0] ?? null);
-        if (!$scale) {
+        if (is_null($scale)) {
             throw new ERC20Exception('Failed to retrieve ERC20 token decimals/scale value');
         }
 


### PR DESCRIPTION
Updated the script so that it will not throw an error on ERC20 tokens that has decimals set to 0 like the case of Matrexcoin Token with 0xc3e2de0b661cf58f66bde8e896905399ded58af5 contract or token address.